### PR TITLE
Fix production start command for Node.js adapter

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -3,3 +3,6 @@ nixPkgs = ["nodejs_22"]
 
 [variables]
 NODE_VERSION = "22"
+
+[start]
+cmd = "node ./dist/server/entry.mjs"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"version": "0.0.9",
 	"scripts": {
 		"dev": "astro dev",
-		"start": "astro dev",
+		"start": "node ./dist/server/entry.mjs",
 		"build": "astro build",
 		"preview": "astro preview",
 		"astro": "astro"


### PR DESCRIPTION
Updated the start script to run the built server application instead of dev mode. The Node.js adapter in standalone mode builds a server at dist/server/entry.mjs which needs to be run in production.

Changes:
- Updated package.json start script to run the built server
- Added explicit start command to nixpacks.toml

This fixes the "Welcome to nginx" error caused by the server not starting properly.