### PR TITLE
Add bot detection to pageview stats

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -93,10 +93,23 @@ export function getDailyPageViews(days: number = 30): DailyStats[] {
   `).all(cutoffTime) as DailyStats[];
 }
 
+// Detect if a user agent is likely a bot
+export function isLikelyBot(userAgent: string | null): boolean {
+  if (!userAgent) return true;
+
+  const botPatterns = [
+    /bot/i, /crawler/i, /spider/i, /scraper/i,
+    /headless/i, /curl/i, /wget/i, /python/i,
+    /java/i, /apache/i, /http/i, /scan/i
+  ];
+
+  return botPatterns.some(pattern => pattern.test(userAgent));
+}
+
 // Get recent pageviews
 export function getRecentPageViews(limit: number = 100) {
   return db.prepare(`
-    SELECT path, referrer, timestamp, created_at
+    SELECT path, referrer, user_agent, timestamp, created_at
     FROM pageviews
     ORDER BY timestamp DESC
     LIMIT ?

--- a/src/pages/stats.astro
+++ b/src/pages/stats.astro
@@ -9,7 +9,8 @@ import {
   getTotalPageViews,
   getPageViewsByPath,
   getDailyPageViews,
-  getRecentPageViews
+  getRecentPageViews,
+  isLikelyBot
 } from '../lib/db';
 
 // Check for authentication
@@ -189,15 +190,20 @@ const recentViews = getRecentPageViews(20);
 
         <div class="stat-card">
           <h2>Recent Pageviews</h2>
-          {recentViews.map((view: any) => (
-            <div class="recent-item">
-              <div class="recent-path">{view.path}</div>
-              <div class="recent-time">
-                {new Date(view.timestamp).toLocaleString()}
-                {view.referrer && ` • from ${new URL(view.referrer).hostname}`}
+          {recentViews.map((view: any) => {
+            const isBot = isLikelyBot(view.user_agent);
+            return (
+              <div class="recent-item">
+                <div class="recent-path">
+                  {isBot ? '🤖' : '👤'} {view.path}
+                </div>
+                <div class="recent-time">
+                  {new Date(view.timestamp).toLocaleString()}
+                  {view.referrer && ` • from ${new URL(view.referrer).hostname}`}
+                </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </main>
       <Footer />


### PR DESCRIPTION
Added simple bot detection based on user agent patterns to help distinguish between human visitors and automated bots. The Recent Pageviews section now shows:
- 👤 for likely human visitors
- 🤖 for likely bots (crawlers, spiders, headless browsers, etc.)

The detection catches common bot patterns like "bot", "crawler", "spider", "headless", "curl", "wget", etc. Sophisticated bots using real browser user agents will still appear as humans, but this filters out the obvious automated traffic.