### PR TITLE
Exclude stats page from pageview tracking

### DIFF
--- a/src/pages/api/pageview.ts
+++ b/src/pages/api/pageview.ts
@@ -15,6 +15,14 @@ export const POST: APIRoute = async ({ request }) => {
       });
     }
 
+    // Don't track views to the stats page itself
+    if (path === '/stats') {
+      return new Response(JSON.stringify({ success: true, tracked: false }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
     // Get user agent from headers
     const userAgent = request.headers.get('user-agent');
 


### PR DESCRIPTION
The stats page itself shouldn't be tracked in analytics since it's only accessed by the site owner to view statistics. This prevents the stats page from appearing in the most visited pages and cluttering the data with self-referential views.