### PR TITLE
adding the ability to associate a blog post with a project

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -7,7 +7,6 @@ const blog = defineCollection({
 	schema: z.object({
 		title: z.string(),
 		description: z.string(),
-		// Transform string to Date object
 		pubDate: z.union([z.string(), z.date()]).transform((val) => new Date(val)),
 		updatedDate: z
 			.string()
@@ -15,7 +14,8 @@ const blog = defineCollection({
 			.transform((str) => (str ? new Date(str) : undefined)),
 		heroImage: z.string().optional(),
 		heroAlt: z.string().optional(),
-		draft: z.boolean().optional()
+		draft: z.boolean().optional(),
+		projectSlug: z.string().optional()
 	})
 });
 

--- a/src/content/blog/social-feed.md
+++ b/src/content/blog/social-feed.md
@@ -2,6 +2,7 @@
 title: 'Building my Social Feed'
 description: 'the story of building my ongoing lifestream of all my Social Media posts.'
 pubDate: '12 Mar 2026'
+projectSlug: 'social-feed'
 ---
 
 Like a lot of folks, I left Twitter. For me, January 2023 was my last post.

--- a/src/content/projects/social-feed.md
+++ b/src/content/projects/social-feed.md
@@ -59,7 +59,3 @@ packages/
 scripts/        # Import scripts (Twitter, Mastodon, Bluesky)
 data/           # SQLite database + media files
 ```
-
-## Related
-
-- [Building My Social Media Lifestream](/blog/social-feed) - Full project write-up

--- a/src/layouts/ProjectPage.astro
+++ b/src/layouts/ProjectPage.astro
@@ -1,15 +1,37 @@
 ---
-import type { CollectionEntry } from 'astro:content';
 import BaseHead from '../components/BaseHead.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import FormattedDate from '../components/FormattedDate.astro';
 import ExternalLink from '../components/ExternalLink.astro';
 
-type Props = CollectionEntry<'projects'>['data'];
+// type Props = CollectionEntry<'projects'>['data'];
+
+interface Props {
+	project: {
+		title: string;
+		createdDate: string;
+		description: string;
+		status?: string;
+		tags?: string[];
+		repoUrl?: string;
+		liveUrl?: string;
+		heroImage?: string;
+		heroAlt?: string;
+	};
+	updates: Array<{
+		slug: string;
+		data: {
+			title: string;
+			pubDate: Date;
+		};
+	}>;
+}
+
+const { project, updates } = Astro.props;
 
 const { title, description, createdDate, status, tags, repoUrl, liveUrl, heroImage, heroAlt } =
-	Astro.props;
+	project;
 ---
 
 <html lang="en">
@@ -139,6 +161,22 @@ const { title, description, createdDate, status, tags, repoUrl, liveUrl, heroIma
 
 					<hr />
 					<slot />
+
+					{
+						updates.length > 0 && (
+							<section class="project-updates">
+								<h2>Project Updates</h2>
+								<ul>
+									{updates.map((update) => (
+										<li>
+											<FormattedDate date={update.data.pubDate} />
+											<a href={`/blog/${update.slug}`}>{update.data.title}</a>
+										</li>
+									))}
+								</ul>
+							</section>
+						)
+					}
 				</article>
 
 				<div class="blog-navigation">

--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -11,9 +11,16 @@ export async function getStaticPaths() {
 }
 
 const project = Astro.props;
+
+// let's get project updates from the blog
+const blogPosts = await getCollection('blog');
+const projectUpdates = blogPosts
+	.filter((post) => post.data.projectSlug === project.id)
+	.sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime());
+
 const { Content } = await render(project);
 ---
 
-<ProjectPage {...project.data}>
+<ProjectPage project={project.data} updates={projectUpdates}>
 	<Content />
 </ProjectPage>


### PR DESCRIPTION
blog posts can now have an optional 'projectSlug' frontmatter that associates them with a project
project pages now look for blog posts with the same slug and display them at the bottom of the page
